### PR TITLE
Fix README install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ To run the wallet, see the nockchain-wallet [README](./crates/nockchain-wallet/R
 
 ## Install Nockchain
 
-After you've run the setup and build commands, install the wallet:
+After you've run the setup and build commands, install Nockchain:
 
 ```
 make install-nockchain


### PR DESCRIPTION
## Summary
- update Install Nockchain instructions in README

## Testing
- `make test` *(fails: could not download rust toolchain)*