### PR TITLE
Add fake network setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,19 @@ After you've run the setup and build commands, install Nockchain:
 make install-nockchain
 ```
 
+## FakeNet Quick Start
+
+Use the helper script to bootstrap a local fakenet node:
+
+```bash
+MINING_PUBKEY=<your_pubkey> scripts/setup-fakenet.sh
+```
+
+The script installs prerequisites, builds and installs the project, then
+starts `nockchain --fakenet` with limits tuned to your hardware. Provide the
+mining public key via the `MINING_PUBKEY` environment variable.
+
+
 
 ## Testing Nodes
 

--- a/scripts/setup-fakenet.sh
+++ b/scripts/setup-fakenet.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install prerequisites
+if ! command -v rustup >/dev/null 2>&1; then
+    curl https://sh.rustup.rs -sSf | sh -s -- -y
+    source "$HOME/.cargo/env"
+else
+    rustup update
+fi
+
+if command -v apt-get >/dev/null 2>&1; then
+    sudo apt-get update
+    sudo apt-get install -y build-essential pkg-config libssl-dev clang cmake
+fi
+
+# Build and install
+make build
+make install-nockchain
+make install-nockchain-wallet
+
+CPU_COUNT=$(nproc)
+MEM_KB=$(grep MemTotal /proc/meminfo | awk '{print $2}')
+MEM_BYTES=$((MEM_KB * 1024))
+MEM_LIMIT_BYTES=$((MEM_BYTES / 2))
+
+MAX_ESTABLISHED=$((CPU_COUNT * 8))
+MAX_INCOMING=$((MAX_ESTABLISHED / 2))
+MAX_OUTGOING=$((MAX_ESTABLISHED / 2))
+
+exec nockchain --fakenet \
+  --mining-pubkey "${MINING_PUBKEY:?MINING_PUBKEY not set}" \
+  --max-established "${MAX_ESTABLISHED}" \
+  --max-established-incoming "${MAX_INCOMING}" \
+  --max-established-outgoing "${MAX_OUTGOING}" \
+  --max-pending-incoming "${MAX_INCOMING}" \
+  --max-pending-outgoing "${MAX_OUTGOING}" \
+  --max-established-per-peer 2 \
+  --max-system-memory-bytes "${MEM_LIMIT_BYTES}"


### PR DESCRIPTION
## Summary
- add `scripts/setup-fakenet.sh` to automate build/install and launch a fakenet node
- document the new helper script in the README

## Testing
- `cargo test --release` *(fails: could not download Rust toolchain)*