### PR TITLE
Add tmux option for fakenet script

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,20 @@ The script installs prerequisites, builds and installs the project, then
 starts `nockchain --fakenet` with limits tuned to your hardware. Provide the
 mining public key via the `MINING_PUBKEY` environment variable.
 
+To spin up both a leader and a follower in detached tmux sessions run:
+
+```bash
+MINING_PUBKEY=<your_pubkey> scripts/setup-fakenet.sh --tmux
+```
+
+This will execute:
+
+```bash
+tmux new-session -d -s nock_leader "make run-nockchain-leader"
+tmux new-session -d -s nock_follower "make run-nockchain-follower"
+```
+You can then attach with `tmux attach -t nock_leader` or `tmux attach -t nock_follower`.
+
 
 
 ## Testing Nodes

--- a/scripts/setup-fakenet.sh
+++ b/scripts/setup-fakenet.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+usage() {
+    echo "Usage: MINING_PUBKEY=<pubkey> $0 [--tmux]" >&2
+    exit 1
+}
+
+if [[ $# -gt 1 ]]; then
+    usage
+fi
+
 # Install prerequisites
 if ! command -v rustup >/dev/null 2>&1; then
     curl https://sh.rustup.rs -sSf | sh -s -- -y
@@ -18,6 +27,13 @@ fi
 make build
 make install-nockchain
 make install-nockchain-wallet
+
+if [[ "${1:-}" == "--tmux" ]]; then
+    tmux new-session -d -s nock_leader "make run-nockchain-leader"
+    tmux new-session -d -s nock_follower "make run-nockchain-follower"
+    echo "Started tmux sessions 'nock_leader' and 'nock_follower'"
+    exit 0
+fi
 
 CPU_COUNT=$(nproc)
 MEM_KB=$(grep MemTotal /proc/meminfo | awk '{print $2}')


### PR DESCRIPTION
## Summary
- add `--tmux` option to `setup-fakenet.sh` for launching leader and follower in tmux
- document tmux usage in FakeNet Quick Start
- make `setup-fakenet.sh` executable

## Testing
- `cargo test --release` *(fails: could not download Rust toolchain)*