### PR TITLE
Allow overriding mining pubkey

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@
 export RUST_BACKTRACE := full
 export RUST_LOG := info,nockchain=debug,nockchain_libp2p_io=info,libp2p=info,libp2p_quic=info
 export MINIMAL_LOG_FORMAT := true
-export MINING_PUBKEY := EHmKL2U3vXfS5GYAY5aVnGdukfDWwvkQPCZXnjvZVShsSQi3UAuA4tQQpVwGJMzc9FfpTY8pLDkqhBGfWutiF4prrCktUH9oAWJxkXQBzAavKDc95NR3DjmYwnnw8GuugnK
+MINING_PUBKEY ?= EHmKL2U3vXfS5GYAY5aVnGdukfDWwvkQPCZXnjvZVShsSQi3UAuA4tQQpVwGJMzc9FfpTY8pLDkqhBGfWutiF4prrCktUH9oAWJxkXQBzAavKDc95NR3DjmYwnnw8GuugnK
+export MINING_PUBKEY
 
 
 .PHONY: build


### PR DESCRIPTION
## Summary
- allow environment variable MINING_PUBKEY to override default in Makefile

## Testing
- `cargo build --release` (from CI)
