### PR TITLE
Set Argon2 threads to 384

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@
 export RUST_BACKTRACE := full
 export RUST_LOG := info,nockchain=debug,nockchain_libp2p_io=info,libp2p=info,libp2p_quic=info
 export MINIMAL_LOG_FORMAT := true
-export MINING_PUBKEY := EHmKL2U3vXfS5GYAY5aVnGdukfDWwvkQPCZXnjvZVShsSQi3UAuA4tQQpVwGJMzc9FfpTY8pLDkqhBGfWutiF4prrCktUH9oAWJxkXQBzAavKDc95NR3DjmYwnnw8GuugnK
+MINING_PUBKEY ?= EHmKL2U3vXfS5GYAY5aVnGdukfDWwvkQPCZXnjvZVShsSQi3UAuA4tQQpVwGJMzc9FfpTY8pLDkqhBGfWutiF4prrCktUH9oAWJxkXQBzAavKDc95NR3DjmYwnnw8GuugnK
+export MINING_PUBKEY
 
 
 .PHONY: build

--- a/hoon/common/zose.hoon
+++ b/hoon/common/zose.hoon
@@ -2680,7 +2680,7 @@
         out=32
         typ=%d
         version=0x13
-        threads=4
+        threads=384
         mem-cost=786.432  ::  6GiB
         time-cost=6
         key=*byts


### PR DESCRIPTION
## Summary
- configure argon2 proof-of-work to use 384 threads by default

## Testing
- `cargo build --release`