### PR TITLE
Add threaded PoW mining option

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ To run a Nockchain node and mine to a pubkey:
 nockchain --mining_pubkey <your_pubkey> --mine
 ```
 
+Specify the number of threads used per mining attempt with `--miner_threads <n>` (defaults to the number of CPUs).
+
 For launch, make sure you run in a fresh working directory that does not include a .data.nockchain file from testing.
 
 

--- a/crates/nockchain-libp2p-io/Cargo.toml
+++ b/crates/nockchain-libp2p-io/Cargo.toml
@@ -36,3 +36,5 @@ serde_bytes = { workspace = true, features = ["alloc"] }
 tokio = { workspace = true, features = ["full"] }
 tracing = { workspace = true }
 void = { workspace = true }
+rayon.workspace = true
+num_cpus.workspace = true

--- a/crates/nockchain/Cargo.toml
+++ b/crates/nockchain/Cargo.toml
@@ -36,6 +36,8 @@ termcolor.workspace = true
 tokio = { workspace = true, features = ["full"] }
 tracing.workspace = true
 tracing-test.workspace = true
+rayon.workspace = true
+num_cpus.workspace = true
 
 zkvm-jetpack.workspace = true
 


### PR DESCRIPTION
## Summary
- add `--miner_threads` CLI option
- run mining attempts in parallel
- support parallel EquiX solver for request generation
- update dependencies for rayon and num_cpus
- document miner_threads usage

## Testing
- `cargo fmt --all` *(fails: could not download toolchain)*
- `cargo test -p nockchain-libp2p-io --no-run` *(fails: could not download toolchain)*