### PR TITLE
Use preloaded kernels for mining

### DIFF
--- a/crates/nockchain/Cargo.toml
+++ b/crates/nockchain/Cargo.toml
@@ -38,6 +38,7 @@ tracing.workspace = true
 tracing-test.workspace = true
 
 zkvm-jetpack.workspace = true
+num_cpus.workspace = true
 
 [build-dependencies]
 vergen = { workspace = true, features = [


### PR DESCRIPTION
## Summary
- preload prover hot state and several kernels on driver init
- store kernels in a shared pool
- reuse kernels for mining attempts
- add `num_cpus` dependency

## Testing
- `cargo test --release` *(fails: could not download toolchain)*
- `cargo fmt` *(fails: could not download toolchain)*
- `cargo check --locked --release --offline` *(fails: could not download toolchain)*