### PR TITLE
Add configurable mining workers

### DIFF
--- a/crates/nockchain/src/lib.rs
+++ b/crates/nockchain/src/lib.rs
@@ -178,6 +178,8 @@ pub struct NockchainCli {
     pub npc_socket: String,
     #[arg(long, help = "Mine in-kernel", default_value = "false")]
     pub mine: bool,
+    #[arg(long, help = "Number of mining worker tasks", default_value_t = 1)]
+    pub mining_workers: usize,
     #[arg(
         long,
         help = "Pubkey to mine to (mutually exclusive with --mining-key-adv)"
@@ -565,9 +567,14 @@ pub async fn init_with_kernel(
     });
 
     let mine = cli.as_ref().map_or(false, |c| c.mine);
+    let mining_workers = cli.as_ref().map_or(1, |c| c.mining_workers);
 
-    let mining_driver =
-        crate::mining::create_mining_driver(mining_config, mine, Some(mining_init_tx));
+    let mining_driver = crate::mining::create_mining_driver(
+        mining_config,
+        mine,
+        Some(mining_init_tx),
+        mining_workers,
+    );
     nockapp.add_io_driver(mining_driver).await;
 
     let libp2p_driver = nockchain_libp2p_io::nc::make_libp2p_driver(

--- a/crates/nockchain/src/mining.rs
+++ b/crates/nockchain/src/mining.rs
@@ -12,6 +12,9 @@ use nockvm::noun::{Atom, D, T};
 use nockvm_macros::tas;
 use tempfile::tempdir;
 use tracing::{instrument, warn};
+use std::sync::Arc;
+use tokio::sync::Mutex;
+use tokio::sync::mpsc;
 
 pub enum MiningWire {
     Mined,
@@ -75,6 +78,7 @@ pub fn create_mining_driver(
     mining_config: Option<Vec<MiningKeyConfig>>,
     mine: bool,
     init_complete_tx: Option<tokio::sync::oneshot::Sender<()>>,
+    workers: usize,
 ) -> IODriverFn {
     Box::new(move |mut handle| {
         Box::pin(async move {
@@ -111,49 +115,41 @@ pub fn create_mining_driver(
             if !mine {
                 return Ok(());
             }
-            let mut next_attempt: Option<NounSlab> = None;
-            let mut current_attempt: tokio::task::JoinSet<()> = tokio::task::JoinSet::new();
+
+            let (candidate_tx, candidate_rx) = mpsc::unbounded_channel::<NounSlab>();
+            let candidate_rx = Arc::new(Mutex::new(candidate_rx));
+
+            for _ in 0..workers.max(1) {
+                let rx = Arc::clone(&candidate_rx);
+                let (cur_handle, mut worker_handle) = handle.dup();
+                handle = cur_handle;
+                tokio::spawn(async move {
+                    while let Some(candidate) = {
+                        let mut guard = rx.lock().await;
+                        guard.recv().await
+                    } {
+                        let (next_handle, attempt_handle) = worker_handle.dup();
+                        worker_handle = next_handle;
+                        mining_attempt(candidate, attempt_handle).await;
+                    }
+                });
+            }
 
             loop {
-                tokio::select! {
-                    effect_res = handle.next_effect() => {
-                        let Ok(effect) = effect_res else {
-                          warn!("Error receiving effect in mining driver: {effect_res:?}");
-                        continue;
-                        };
-                        let Ok(effect_cell) = (unsafe { effect.root().as_cell() }) else {
-                            drop(effect);
-                            continue;
-                        };
+                let effect_res = handle.next_effect().await;
+                let Ok(effect) = effect_res else {
+                    warn!("Error receiving effect in mining driver: {effect_res:?}");
+                    continue;
+                };
+                let Ok(effect_cell) = (unsafe { effect.root().as_cell() }) else {
+                    drop(effect);
+                    continue;
+                };
 
-                        if effect_cell.head().eq_bytes("mine") {
-                            let candidate_slab = {
-                                let mut slab = NounSlab::new();
-                                slab.copy_into(effect_cell.tail());
-                                slab
-                            };
-                            if !current_attempt.is_empty() {
-                                next_attempt = Some(candidate_slab);
-                            } else {
-                                let (cur_handle, attempt_handle) = handle.dup();
-                                handle = cur_handle;
-                                current_attempt.spawn(mining_attempt(candidate_slab, attempt_handle));
-                            }
-                        }
-                    },
-                    mining_attempt_res = current_attempt.join_next(), if !current_attempt.is_empty()  => {
-                        if let Some(Err(e)) = mining_attempt_res {
-                            warn!("Error during mining attempt: {e:?}");
-                        }
-                        let Some(candidate_slab) = next_attempt else {
-                            continue;
-                        };
-                        next_attempt = None;
-                        let (cur_handle, attempt_handle) = handle.dup();
-                        handle = cur_handle;
-                        current_attempt.spawn(mining_attempt(candidate_slab, attempt_handle));
-
-                    }
+                if effect_cell.head().eq_bytes("mine") {
+                    let mut slab = NounSlab::new();
+                    slab.copy_into(effect_cell.tail());
+                    let _ = candidate_tx.send(slab);
                 }
             }
         })


### PR DESCRIPTION
## Summary
- expose `--mining-workers` option on CLI
- run multiple parallel mining workers

## Testing
- `cargo test --release` *(fails: could not download toolchain)*