### PR TITLE
Add configurable Nock stack size

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,13 @@ nockchain --mining_pubkey <your_pubkey> --mine
 
 For launch, make sure you run in a fresh working directory that does not include a .data.nockchain file from testing.
 
+### Memory Tuning
+
+The Nock VM uses a large stack. You can adjust its size with `--nock-stack-size-mb`.
+The default is 1024 MB. Mining attempts allocate a stack 16× this size.
+Reducing the value lowers memory usage and enables more parallel mining
+threads, but setting it too low may cause stack overflows.
+
 
 ## FAQ
 

--- a/crates/hoonc/src/lib.rs
+++ b/crates/hoonc/src/lib.rs
@@ -201,6 +201,7 @@ pub async fn initialize_hoonc_(
         &[],
         "hoonc",
         Some(data_dir),
+        None,
     )
     .await?;
     let mut slab = NounSlab::new();

--- a/crates/nockapp/src/kernel/boot.rs
+++ b/crates/nockapp/src/kernel/boot.rs
@@ -4,6 +4,7 @@ use crate::{default_data_dir, NockApp};
 use chrono;
 use clap::{arg, command, ColorChoice, Parser};
 use nockvm::jets::hot::HotEntry;
+use crate::utils::NOCK_STACK_SIZE;
 use std::fs;
 use std::path::PathBuf;
 use tracing::{debug, info, Level};
@@ -211,6 +212,7 @@ pub async fn setup(
     hot_state: &[HotEntry],
     name: &str,
     data_dir: Option<PathBuf>,
+    nock_stack_size: Option<usize>,
 ) -> Result<NockApp, Box<dyn std::error::Error>> {
     let result = setup_(
         jam,
@@ -218,6 +220,7 @@ pub async fn setup(
         hot_state,
         name,
         data_dir,
+        nock_stack_size.unwrap_or(NOCK_STACK_SIZE),
     )
     .await?;
     match result {
@@ -235,6 +238,7 @@ pub async fn setup_(
     hot_state: &[HotEntry],
     name: &str,
     data_dir: Option<PathBuf>,
+    nock_stack_size: usize,
 ) -> Result<SetupResult, Box<dyn std::error::Error>> {
     let data_dir = if let Some(data_path) = data_dir.clone() {
         data_path.join(name)
@@ -270,10 +274,26 @@ pub async fn setup_(
     let mut kernel = if let Some(state_path) = cli.state_jam {
         let state_bytes = fs::read(&state_path)?;
         debug!("kernel: loading state from jam file: {:?}", state_path);
-        Kernel::load_with_kernel_state(pma_dir, jam_paths, jam, &state_bytes, hot_state, cli.trace)
+        Kernel::load_with_kernel_state(
+            pma_dir,
+            jam_paths,
+            jam,
+            &state_bytes,
+            hot_state,
+            cli.trace,
+            nock_stack_size,
+        )
             .await?
     } else {
-        Kernel::load_with_hot_state(pma_dir, jam_paths, jam, hot_state, cli.trace).await?
+        Kernel::load_with_hot_state(
+            pma_dir,
+            jam_paths,
+            jam,
+            hot_state,
+            cli.trace,
+            nock_stack_size,
+        )
+        .await?
     };
 
     if let Some(export_path) = cli.export_state_jam.clone() {

--- a/crates/nockapp/src/kernel/form.rs
+++ b/crates/nockapp/src/kernel/form.rs
@@ -581,13 +581,18 @@ impl Kernel {
         kernel: &[u8],
         hot_state: &[HotEntry],
         trace: bool,
+        nock_stack_size: usize,
     ) -> Result<Self> {
         let jam_paths_arc = Arc::new(jam_paths);
         let kernel_vec = Vec::from(kernel);
         let hot_state_vec = Vec::from(hot_state);
         let pma_dir_arc = Arc::new(pma_dir);
         let serf = SerfThread::new(
-            NOCK_STACK_SIZE, jam_paths_arc, kernel_vec, hot_state_vec, trace,
+            nock_stack_size,
+            jam_paths_arc,
+            kernel_vec,
+            hot_state_vec,
+            trace,
         )
         .await?;
         Ok(Self {
@@ -602,13 +607,18 @@ impl Kernel {
         kernel: &[u8],
         hot_state: &[HotEntry],
         trace: bool,
+        nock_stack_size: usize,
     ) -> Result<Self> {
         let jam_paths_arc = Arc::new(jam_paths);
         let kernel_vec = Vec::from(kernel);
         let hot_state_vec = Vec::from(hot_state);
         let pma_dir_arc = Arc::new(pma_dir);
         let serf = SerfThread::new(
-            NOCK_STACK_SIZE_HUGE, jam_paths_arc, kernel_vec, hot_state_vec, trace,
+            nock_stack_size,
+            jam_paths_arc,
+            kernel_vec,
+            hot_state_vec,
+            trace,
         )
         .await?;
         Ok(Self {
@@ -634,7 +644,15 @@ impl Kernel {
         kernel: &[u8],
         trace: bool,
     ) -> Result<Self> {
-        Self::load_with_hot_state(pma_dir, jam_paths, kernel, &Vec::new(), trace).await
+        Self::load_with_hot_state(
+            pma_dir,
+            jam_paths,
+            kernel,
+            &Vec::new(),
+            trace,
+            NOCK_STACK_SIZE,
+        )
+        .await
     }
 
     /// Loads a kernel with state from jammed bytes
@@ -645,9 +663,10 @@ impl Kernel {
         state_bytes: &[u8],
         hot_state: &[HotEntry],
         trace: bool,
+        nock_stack_size: usize,
     ) -> Result<Self> {
         let kernel =
-            Self::load_with_hot_state(pma_dir, jam_paths, kernel_jam, hot_state, trace).await?;
+            Self::load_with_hot_state(pma_dir, jam_paths, kernel_jam, hot_state, trace, nock_stack_size).await?;
 
         match kernel
             .serf

--- a/crates/nockchain-wallet/src/main.rs
+++ b/crates/nockchain-wallet/src/main.rs
@@ -747,6 +747,7 @@ async fn main() -> Result<(), NockAppError> {
         prover_hot_state.as_slice(),
         "wallet",
         Some(data_dir),
+        None,
     )
     .await
     .map_err(|e| CrownError::Unknown(format!("Kernel setup failed: {}", e)))?;
@@ -932,6 +933,7 @@ mod tests {
             prover_hot_state.as_slice(),
             "wallet",
             None,
+            None,
         )
         .await
         .map_err(|e| CrownError::Unknown(e.to_string()))?;
@@ -970,6 +972,7 @@ mod tests {
             Some(cli.clone()),
             prover_hot_state.as_slice(),
             "wallet",
+            None,
             None,
         )
         .await
@@ -1014,7 +1017,7 @@ mod tests {
     async fn test_sign_tx() -> Result<(), NockAppError> {
         init_tracing();
         let cli = BootCli::parse_from(&[""]);
-        let nockapp = boot::setup(KERNEL, Some(cli.clone()), &[], "wallet", None)
+        let nockapp = boot::setup(KERNEL, Some(cli.clone()), &[], "wallet", None, None)
             .await
             .map_err(|e| CrownError::Unknown(e.to_string()))?;
         let mut wallet = Wallet::new(nockapp);
@@ -1069,7 +1072,7 @@ mod tests {
     async fn test_gen_master_privkey() -> Result<(), NockAppError> {
         init_tracing();
         let cli = BootCli::parse_from(&[""]);
-        let nockapp = boot::setup(KERNEL, Some(cli.clone()), &[], "wallet", None)
+        let nockapp = boot::setup(KERNEL, Some(cli.clone()), &[], "wallet", None, None)
             .await
             .map_err(|e| CrownError::Unknown(e.to_string()))?;
         let mut wallet = Wallet::new(nockapp);
@@ -1090,7 +1093,7 @@ mod tests {
     async fn test_gen_master_pubkey() -> Result<(), NockAppError> {
         init_tracing();
         let cli = BootCli::parse_from(&[""]);
-        let nockapp = boot::setup(KERNEL, Some(cli.clone()), &[], "wallet", None)
+        let nockapp = boot::setup(KERNEL, Some(cli.clone()), &[], "wallet", None, None)
             .await
             .map_err(|e| CrownError::Unknown(e.to_string()))?;
         let mut wallet = Wallet::new(nockapp);
@@ -1112,7 +1115,7 @@ mod tests {
     async fn test_import_keys() -> Result<(), NockAppError> {
         init_tracing();
         let cli = BootCli::parse_from(&["--new"]);
-        let nockapp = boot::setup(KERNEL, Some(cli.clone()), &[], "wallet", None)
+        let nockapp = boot::setup(KERNEL, Some(cli.clone()), &[], "wallet", None, None)
             .await
             .map_err(|e| CrownError::Unknown(e.to_string()))?;
         let mut wallet = Wallet::new(nockapp);
@@ -1152,7 +1155,7 @@ mod tests {
     async fn test_simple_scan() -> Result<(), NockAppError> {
         init_tracing();
         let cli = BootCli::parse_from(&[""]);
-        let nockapp = boot::setup(KERNEL, Some(cli.clone()), &[], "wallet", None)
+        let nockapp = boot::setup(KERNEL, Some(cli.clone()), &[], "wallet", None, None)
             .await
             .map_err(|e| CrownError::Unknown(e.to_string()))?;
         let mut wallet = Wallet::new(nockapp);
@@ -1176,7 +1179,7 @@ mod tests {
     async fn test_simple_spend_multisig_format() -> Result<(), NockAppError> {
         init_tracing();
         let cli = BootCli::parse_from(&[""]);
-        let nockapp = boot::setup(KERNEL, Some(cli.clone()), &[], "wallet", None)
+        let nockapp = boot::setup(KERNEL, Some(cli.clone()), &[], "wallet", None, None)
             .await
             .map_err(|e| CrownError::Unknown(e.to_string()))?;
         let mut wallet = Wallet::new(nockapp);
@@ -1205,7 +1208,7 @@ mod tests {
     #[cfg_attr(miri, ignore)]
     async fn test_simple_spend_single_sig_format() -> Result<(), NockAppError> {
         let cli = BootCli::parse_from(&[""]);
-        let nockapp = boot::setup(KERNEL, Some(cli.clone()), &[], "wallet", None)
+        let nockapp = boot::setup(KERNEL, Some(cli.clone()), &[], "wallet", None, None)
             .await
             .map_err(|e| CrownError::Unknown(e.to_string()))?;
         init_tracing();
@@ -1247,7 +1250,7 @@ mod tests {
     async fn test_update_balance() -> Result<(), NockAppError> {
         init_tracing();
         let cli = BootCli::parse_from(&["--new"]);
-        let nockapp = boot::setup(KERNEL, Some(cli.clone()), &[], "wallet", None)
+        let nockapp = boot::setup(KERNEL, Some(cli.clone()), &[], "wallet", None, None)
             .await
             .map_err(|e| CrownError::Unknown(e.to_string()))?;
         let mut wallet = Wallet::new(nockapp);
@@ -1266,7 +1269,7 @@ mod tests {
     async fn test_list_notes() -> Result<(), NockAppError> {
         init_tracing();
         let cli = BootCli::parse_from(&[""]);
-        let nockapp = boot::setup(KERNEL, Some(cli.clone()), &[], "wallet", None)
+        let nockapp = boot::setup(KERNEL, Some(cli.clone()), &[], "wallet", None, None)
             .await
             .map_err(|e| CrownError::Unknown(e.to_string()))?;
         let mut wallet = Wallet::new(nockapp);
@@ -1286,7 +1289,7 @@ mod tests {
     async fn test_make_tx_from_draft() -> Result<(), NockAppError> {
         init_tracing();
         let cli = BootCli::parse_from(&[""]);
-        let nockapp = boot::setup(KERNEL, Some(cli.clone()), &[], "wallet", None)
+        let nockapp = boot::setup(KERNEL, Some(cli.clone()), &[], "wallet", None, None)
             .await
             .map_err(|e| CrownError::Unknown(e.to_string()))?;
         let mut wallet = Wallet::new(nockapp);

--- a/crates/nockchain/src/lib.rs
+++ b/crates/nockchain/src/lib.rs
@@ -211,6 +211,8 @@ pub struct NockchainCli {
     pub btc_password: Option<String>,
     #[arg(long, help = "Auth cookie path for Bitcoin Core RPC")]
     pub btc_auth_cookie: Option<String>,
+    #[arg(long, help = "Nock stack size in MB")]
+    pub nock_stack_size_mb: Option<usize>,
     #[arg(long, short, help = "Initial peer", action = ArgAction::Append)]
     pub peer: Vec<String>,
     #[arg(long, help = "Allowed peer IDs file")]
@@ -364,12 +366,18 @@ pub async fn init_with_kernel(
         cli.validate()?;
     }
 
+    let stack_size_bytes = cli
+        .as_ref()
+        .and_then(|c| c.nock_stack_size_mb.map(|mb| mb * 1024 * 1024))
+        .unwrap_or(nockapp::utils::NOCK_STACK_SIZE);
+
     let mut nockapp = boot::setup(
         kernel_jam,
         cli.as_ref().map(|c| c.nockapp_cli.clone()),
         hot_state,
         "nockchain",
         None,
+        Some(stack_size_bytes),
     )
     .await?;
 
@@ -566,8 +574,15 @@ pub async fn init_with_kernel(
 
     let mine = cli.as_ref().map_or(false, |c| c.mine);
 
-    let mining_driver =
-        crate::mining::create_mining_driver(mining_config, mine, Some(mining_init_tx));
+    let huge_stack_size = stack_size_bytes
+        * (nockapp::utils::NOCK_STACK_SIZE_HUGE / nockapp::utils::NOCK_STACK_SIZE);
+
+    let mining_driver = crate::mining::create_mining_driver(
+        mining_config,
+        mine,
+        Some(mining_init_tx),
+        huge_stack_size,
+    );
     nockapp.add_io_driver(mining_driver).await;
 
     let libp2p_driver = nockchain_libp2p_io::nc::make_libp2p_driver(


### PR DESCRIPTION
## Summary
- expose `--nock-stack-size-mb` in `NockchainCli`
- pipe stack size through boot setup and mining kernel creation
- update wallet, hoonc and nockchain to new boot API
- document stack size tuning in README

## Testing
- `cargo fmt` *(fails: could not download file)*
- `cargo test --workspace --all-targets --quiet` *(fails: could not download file)*