### PR TITLE
Add mining-workers option

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ nockchain
 To run a Nockchain node and mine to a pubkey:
 
 ```
-nockchain --mining_pubkey <your_pubkey> --mine
+nockchain --mining_pubkey <your_pubkey> --mine --mining-workers <num_workers>
 ```
 
 For launch, make sure you run in a fresh working directory that does not include a .data.nockchain file from testing.

--- a/crates/nockchain/src/lib.rs
+++ b/crates/nockchain/src/lib.rs
@@ -241,6 +241,8 @@ pub struct NockchainCli {
     pub max_system_memory_fraction: Option<f64>,
     #[arg(long, help = "Maximum process memory for connection limits (bytes)")]
     pub max_system_memory_bytes: Option<usize>,
+    #[arg(long, help = "Number of mining workers")]
+    pub mining_workers: Option<usize>,
 }
 
 impl NockchainCli {
@@ -566,8 +568,9 @@ pub async fn init_with_kernel(
 
     let mine = cli.as_ref().map_or(false, |c| c.mine);
 
+    let mining_workers = cli.as_ref().and_then(|c| c.mining_workers);
     let mining_driver =
-        crate::mining::create_mining_driver(mining_config, mine, Some(mining_init_tx));
+        crate::mining::create_mining_driver(mining_config, mine, mining_workers, Some(mining_init_tx));
     nockapp.add_io_driver(mining_driver).await;
 
     let libp2p_driver = nockchain_libp2p_io::nc::make_libp2p_driver(

--- a/crates/nockchain/src/mining.rs
+++ b/crates/nockchain/src/mining.rs
@@ -83,6 +83,7 @@ impl FromStr for MiningKeyConfig {
 pub fn create_mining_driver(
     mining_config: Option<Vec<MiningKeyConfig>>,
     mine: bool,
+    workers: Option<usize>,
     init_complete_tx: Option<tokio::sync::oneshot::Sender<()>>,
 ) -> IODriverFn {
     Box::new(move |mut handle| {
@@ -121,7 +122,7 @@ pub fn create_mining_driver(
             }
 
             if mine {
-                let num_kernels = num_cpus::get();
+                let num_kernels = workers.unwrap_or_else(num_cpus::get);
                 for _ in 0..num_kernels {
                     let snapshot_dir = tokio::task::spawn_blocking(|| {
                         tempdir().expect("Failed to create temporary directory")


### PR DESCRIPTION
## Summary
- add `--mining-workers` option in `NockchainCli`
- allow `create_mining_driver` to accept worker count
- use CLI worker count when preloading mining kernels
- document the new option in README usage example

## Testing
- `cargo check -p nockchain` *(fails: no network access)*