### PR TITLE
Make nock stack size configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,12 @@ nockchain --mining_pubkey <your_pubkey> --mine
 
 For launch, make sure you run in a fresh working directory that does not include a .data.nockchain file from testing.
 
+### Nock Stack Size
+
+Use the `--nock-stack-size-mb` flag to control how much memory is reserved for the
+Nock runtime stack. The default is `1024` (1 GB). On most machines we recommend at
+least `4096` and miners may wish to use `16384`.
+
 
 ## FAQ
 

--- a/crates/nockapp/src/utils/mod.rs
+++ b/crates/nockapp/src/utils/mod.rs
@@ -33,12 +33,6 @@ const S1: u128 = 18446744073709551616;
 
 pub const NOCK_STACK_1KB: usize = 1 << 7;
 
-// nock stack size
-pub const NOCK_STACK_SIZE: usize = (NOCK_STACK_1KB << 10 << 10) * 8; // 8GB
-
-// HUGE nock stack size
-pub const NOCK_STACK_SIZE_HUGE: usize = (NOCK_STACK_1KB << 10 << 10) * 128; // 32GB
-
 /**
  *   ::  +from-unix: unix seconds to @da
  *   ::

--- a/crates/nockchain/src/mining.rs
+++ b/crates/nockchain/src/mining.rs
@@ -83,6 +83,7 @@ impl FromStr for MiningKeyConfig {
 pub fn create_mining_driver(
     mining_config: Option<Vec<MiningKeyConfig>>,
     mine: bool,
+    nock_stack_size: usize,
     init_complete_tx: Option<tokio::sync::oneshot::Sender<()>>,
 ) -> IODriverFn {
     Box::new(move |mut handle| {
@@ -136,6 +137,7 @@ pub fn create_mining_driver(
                         KERNEL,
                         &prover_hot_state,
                         false,
+                        nock_stack_size,
                     )
                     .await
                     .expect("Could not load mining kernel");


### PR DESCRIPTION
## Summary
- add `--nock-stack-size-mb` CLI flag to set stack size
- thread stack size through boot setup and kernel loading
- use user-supplied stack size when mining
- drop old NOCK_STACK_SIZE constants
- document recommended stack sizes in the README

## Testing
- `cargo fmt` *(fails: could not download rustfmt)*
- `cargo test --workspace --all-targets` *(fails: could not download toolchain)*