### PR TITLE
Enable concurrent mining workers

### DIFF
--- a/crates/nockchain/Cargo.toml
+++ b/crates/nockchain/Cargo.toml
@@ -39,6 +39,7 @@ tracing-test.workspace = true
 
 zkvm-jetpack.workspace = true
 num_cpus.workspace = true
+crossbeam-queue = "0.3.12"
 
 [build-dependencies]
 vergen = { workspace = true, features = [


### PR DESCRIPTION
## Summary
- add a `--mining-workers` CLI option
- process mining candidates using a shared queue
- spawn a worker loop per configured worker

## Testing
- `cargo check -p nockchain --locked --offline` *(fails: could not download toolchain)*